### PR TITLE
fix: correct spelling sucesfully -> successfully

### DIFF
--- a/guided-install.sh
+++ b/guided-install.sh
@@ -128,7 +128,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
 fi
 
 # Print finishing off message
-echo -e "\n✅ ${HEADING_COLOR}Tasks completed sucesfully in $((`date +%s`-START_TIME)) seconds${RESET}"
+echo -e "\n✅ ${HEADING_COLOR}Tasks completed successfully in $((`date +%s`-START_TIME)) seconds${RESET}"
 echo -e "\x1b[2m\n.~~~~.\n\033[0;33m\x1b[2mi====i_\n|cccc|_)\n|cccc|\n\`-==-'\n${RESET}"
 echo -e "\033[0;33m\x1b[2mThank you for using Lissy93/Brewfile${RESET}"
 unset PROMPT_TIMEOUT


### PR DESCRIPTION
## Summary
Corrects a typo in the guided-install.sh script.

## Change
- `sucesfully` → `successfully` in echo statement (line 131)

## Why
Simple typo fix in a user-facing success message.

---
One-character fix: s/sucesfully/successfully/